### PR TITLE
core-services/sysctl: allow system file masking

### DIFF
--- a/core-services/08-sysctl.sh
+++ b/core-services/08-sysctl.sh
@@ -2,15 +2,19 @@
 
 if [ -x /sbin/sysctl -o -x /bin/sysctl ]; then
     msg "Loading sysctl(8) settings..."
+    mkdir /run/sysctl
     for i in /run/sysctl.d/*.conf \
         /etc/sysctl.d/*.conf \
         /usr/local/lib/sysctl.d/*.conf \
         /usr/lib/sysctl.d/*.conf \
         /etc/sysctl.conf; do
 
-        if [ -e "$i" ]; then
+        fname="/run/sysctl/${i##*/}"
+        if [ -e "$i" ] && [ ! -e "$fname" -o "$i" = "/etc/sysctl.conf" ]; then
             printf '* Applying %s ...\n' "$i"
             sysctl -p "$i"
+            touch "$fname"
         fi
     done
+    rm -rf /run/sysctl
 fi


### PR DESCRIPTION
This aligns the behavior of this script with `sysctl --system`. If a file
is present in 2 directory, only the first one will be read.

For instance, this allows the user to overwrite
/usr/lib/sysctl.d/void.conf by creating the file /etc/sysctl.d/void.conf.
In that case, only the later will be read.

This does not yield the exact same result as `sysctl --system`. In fact,
with `sysctl --system`, the file order would be:

```
/usr/lib/sysctl.d/1-sysctl.conf
/etc/sysctl.d/2-sysctl.conf
```

While in this case the file order would be:

```
/etc/sysctl.d/2-sysctl.conf
/usr/lib/sysctl.d/1-sysctl.conf
```

This could be solved by copying the file content in /run/sysctl before
executing them. My only concern is that if a file is too big, it could lead to
an unbootable system.