### PR TITLE
vlogger: a couple of bugfixes.

### DIFF
--- a/vlogger.c
+++ b/vlogger.c
@@ -76,8 +76,9 @@ strpriority(char *s, int *facility, int *level)
 int
 main(int argc, char *argv[])
 {
-	char c, *p, *argv0;
+	char*p, *argv0;
 	char *tag = NULL;
+	int c;
 	int facility = LOG_DAEMON;
 	int level = LOG_INFO;
 
@@ -116,13 +117,16 @@ usage:
 
 	openlog(tag, 0, facility);
 
-	char *line;
+	char *line = NULL;
 	size_t linelen = 0;
 	ssize_t rd;
 	while ((rd = getline(&line, &linelen, stdin)) != -1) {
 		if (line[rd-1] == '\n')
 			line[rd-1] = '\0';
 		syslog(level|facility, "%s", line);
+		free(line);
+		line = NULL;
+		linelen = 0;
 	}
 
 	return 1;


### PR DESCRIPTION
* Don't store the return value of getopt in a char.  Storing in a char
  and comparing against -1 breaks on ARM, where char is unsigned.
* The line argument to getline should point at a NULL char *.  Otherwise,
  getline will treat *line as a pointer to an allocated buffer.  With
  a little extra work, we could reuse the buffer, but always calling getline
  with *line == NULL is safe.