### PR TITLE
functions: add missing new line in msg_warn

### DIFF
--- a/functions
+++ b/functions
@@ -17,7 +17,7 @@ msg_error() {
 
 msg_warn() {
     # bold/yellow
-    printf "\033[1m\033[33mWARNING: $@\033[m"
+    printf "\033[1m\033[33mWARNING: $@\033[m\n"
 }
 
 emergency_shell() {


### PR DESCRIPTION
Hi folks, ```\n``` character was missing in ```msg_warn```.