### PR TITLE
remove TTYS configuration from rc.conf

### DIFF
--- a/core-services/03-console-setup.sh
+++ b/core-services/03-console-setup.sh
@@ -2,7 +2,7 @@
 
 [ -n "$VIRTUALIZATION" ] && return 0
 
-TTYS=${TTYS:-12}
+TTYS=6
 if [ -n "$FONT" ]; then
     msg "Setting up TTYs font to '${FONT}'..."
 

--- a/rc.conf
+++ b/rc.conf
@@ -25,5 +25,3 @@
 # Font unimap to load, see setfont(8).
 #FONT_UNIMAP=
 
-# Amount of ttys which should be setup.
-#TTYS=


### PR DESCRIPTION
The configuration option doesn 't actually do anything. There are always at least 6 ttys and agetty starts only on them.