### PR TITLE
Use sysctl --system instead of the broken manual loading

### DIFF
--- a/core-services/08-sysctl.sh
+++ b/core-services/08-sysctl.sh
@@ -2,15 +2,5 @@
 
 if [ -x /sbin/sysctl -o -x /bin/sysctl ]; then
     msg "Loading sysctl(8) settings..."
-    for i in /run/sysctl.d/*.conf \
-        /etc/sysctl.d/*.conf \
-        /usr/local/lib/sysctl.d/*.conf \
-        /usr/lib/sysctl.d/*.conf \
-        /etc/sysctl.conf; do
-
-        if [ -e "$i" ]; then
-            printf '* Applying %s ...\n' "$i"
-            sysctl -p "$i"
-        fi
-    done
+    sysctl --system
 fi


### PR DESCRIPTION
See also https://github.com/void-linux/void-packages/pull/12439 for the reasoning.