### PR TITLE
Change sysctl configuration file order

### DIFF
--- a/core-services/08-sysctl.sh
+++ b/core-services/08-sysctl.sh
@@ -2,11 +2,11 @@
 
 if [ -x /sbin/sysctl -o -x /bin/sysctl ]; then
     msg "Loading sysctl(8) settings..."
-    for i in /run/sysctl.d/*.conf \
-        /etc/sysctl.d/*.conf \
-        /usr/local/lib/sysctl.d/*.conf \
+    for i in /etc/sysctl.conf \
         /usr/lib/sysctl.d/*.conf \
-        /etc/sysctl.conf; do
+        /usr/local/lib/sysctl.d/*.conf \
+        /etc/sysctl.d/*.conf \
+        /run/sysctl.d/*.conf; do
 
         if [ -e "$i" ]; then
             printf '* Applying %s ...\n' "$i"


### PR DESCRIPTION
Currently `sysctl` settings are loaded via various configuration files, in that order:

````
/run/sysctl.d/*.conf
/etc/sysctl.d/*.conf
/usr/local/lib/sysctl.d/*.conf
/usr/lib/sysctl.d/*.conf
/etc/sysctl.conf
````

That means whatever local adjustments have been made, they will be potentially overwritten by whatever is shipped with the OS in `/usr/lib/sysctl.d/` and `/etc/sysctl.conf`. Example: `kernel.dmesg_restrict` is set to `1` in `/usr/lib/sysctl.d/10-void.conf` but setting it to another value in e.g. `/etc/sysctl.d/local.conf` will get overwritten later on. One could adjust `/etc/sysctl.conf` but these changes may get overwritten in the next OS update.

This PR will change the processing order of these files so that local adjustments are possible.