### PR TITLE
halt: add support for wtmp

### DIFF
--- a/3
+++ b/3
@@ -27,7 +27,7 @@ if [ -z "$VIRTUALIZATION" -a -n "$HARDWARECLOCK" ]; then
     hwclock --systohc ${HARDWARECLOCK:+--$(echo $HARDWARECLOCK |tr A-Z a-z)}
 fi
 
-halt -w  # for utmp
+halt -w  # for wtmp
 
 if [ -z "$VIRTUALIZATION" ]; then
     msg "Stopping udev..."

--- a/core-services/05-misc.sh
+++ b/core-services/05-misc.sh
@@ -1,5 +1,6 @@
 # vim: set ts=4 sw=4 et:
 
+install -m0664 -o root -g utmp /dev/null /run/utmp
 halt -B  # for wtmp
 
 if [ -z "$VIRTUALIZATION" ]; then

--- a/core-services/05-misc.sh
+++ b/core-services/05-misc.sh
@@ -1,5 +1,7 @@
 # vim: set ts=4 sw=4 et:
 
+halt -B  # for wtmp
+
 if [ -z "$VIRTUALIZATION" ]; then
     msg "Initializing random seed..."
     cp /var/lib/random-seed /dev/urandom >/dev/null 2>&1 || true

--- a/core-services/99-cleanup.sh
+++ b/core-services/99-cleanup.sh
@@ -1,6 +1,5 @@
 # vim: set ts=4 sw=4 et:
 
-install -m0664 -o root -g utmp /dev/null /run/utmp
 if [ ! -e /var/log/wtmp ]; then
 	install -m0664 -o root -g utmp /dev/null /var/log/wtmp
 fi

--- a/halt.8
+++ b/halt.8
@@ -1,4 +1,4 @@
-.Dd July 29, 2014
+.Dd September 5, 2019
 .Dt HALT 8
 .Os Linux
 .Sh NAME
@@ -10,6 +10,9 @@
 .Nm halt
 .Op Fl n
 .Op Fl f
+.Op Fl d
+.Op Fl w
+.Op Fl B
 .Nm reboot
 .Op Fl n
 .Op Fl f
@@ -40,6 +43,12 @@ Force halt or reboot, don't call
 .Xr init 8 .
 This is
 .Sy dangerous !
+.It Fl d
+Do not write the wtmp record.
+.It Fl w
+Just write the wtmp record.
+.It Fl B
+Just write the wtmp record, but for a boot.
 .El
 .Sh UNSUPPORTED OPTIONS
 This version of
@@ -50,10 +59,6 @@ the following features are
 .Sy not
 supported and silently ignored:
 .Bl -tag -width indent
-.It Fl w
-to just write the wtmp record.
-.It Fl d
-to not write the wtmp record.
 .It Fl h
 to put hard drives in standby mode.
 .It Fl i

--- a/halt.c
+++ b/halt.c
@@ -38,13 +38,13 @@ void write_wtmp(int boot) {
 
   utmp.ut_type = boot ? BOOT_TIME : RUN_LVL;
 
-  strncpy(utmp.ut_name, boot ? "reboot" : "shutdown", sizeof(utmp.ut_name));
-  strncpy(utmp.ut_id , "~~", sizeof(utmp.ut_id));
-  strncpy(utmp.ut_line, boot ? "~" : "~~", sizeof(utmp.ut_line));
+  strncpy(utmp.ut_name, boot ? "reboot" : "shutdown", sizeof utmp.ut_name);
+  strncpy(utmp.ut_id , "~~", sizeof utmp.ut_id);
+  strncpy(utmp.ut_line, boot ? "~" : "~~", sizeof utmp.ut_line);
   if (uname(&uname_buf) == 0)
-    strncpy(utmp.ut_host, uname_buf.release, sizeof(utmp.ut_host));
+    strncpy(utmp.ut_host, uname_buf.release, sizeof utmp.ut_host);
 
-  write(fd, (char *)&utmp, sizeof(utmp));
+  write(fd, (char *)&utmp, sizeof utmp);
   close(fd);
 
   if (boot) {

--- a/halt.c
+++ b/halt.c
@@ -1,16 +1,53 @@
-#include <errno.h>
-#include <unistd.h>
-#include <err.h>
-#include <string.h>
 #include <sys/reboot.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/utsname.h>
+
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+#include <utmp.h>
 
 extern char *__progname;
 
 typedef enum {NOOP, HALT, REBOOT, POWEROFF} action_type;
 
+#ifndef OUR_WTMP
+#define OUR_WTMP "/var/log/wtmp"
+#endif
+
+void write_wtmp(int boot) {
+  int fd;
+
+  if ((fd = open(OUR_WTMP, O_WRONLY|O_APPEND)) < 0)
+    return;
+
+  struct utmp utmp = {0};
+  struct utsname uname_buf;
+  struct timeval tv;
+
+  gettimeofday(&tv, 0);
+  utmp.ut_tv.tv_sec = tv.tv_sec;
+  utmp.ut_tv.tv_usec = tv.tv_usec;
+
+  utmp.ut_type = boot ? BOOT_TIME : RUN_LVL;
+
+  strncpy(utmp.ut_name, boot ? "reboot" : "shutdown", sizeof(utmp.ut_name));
+  strncpy(utmp.ut_id , "~~", sizeof(utmp.ut_id));
+  strncpy(utmp.ut_line, boot ? "~" : "~~", sizeof(utmp.ut_line));
+  if (uname(&uname_buf) == 0)
+    strncpy(utmp.ut_host, uname_buf.release, sizeof(utmp.ut_host));
+
+  write(fd, (char *)&utmp, sizeof(utmp));
+  close(fd);
+}
+
 int main(int argc, char *argv[]) {
   int do_sync = 1;
   int do_force = 0;
+  int do_wtmp = 1;
   int opt;
   action_type action = NOOP;
 
@@ -23,7 +60,7 @@ int main(int argc, char *argv[]) {
   else
     warnx("no default behavior, needs to be called as halt/reboot/poweroff.");
 
-  while ((opt = getopt(argc, argv, "dfhinw")) != -1)
+  while ((opt = getopt(argc, argv, "dfhinwB")) != -1)
     switch (opt) {
     case 'n':
       do_sync = 0;
@@ -33,6 +70,8 @@ int main(int argc, char *argv[]) {
       do_sync = 0;
       break;
     case 'd':
+      do_wtmp = 0;
+      break;
     case 'h':
     case 'i':
       /* silently ignored.  */
@@ -40,9 +79,15 @@ int main(int argc, char *argv[]) {
     case 'f':
       do_force = 1;
       break;
+    case 'B':
+      write_wtmp(1);
+      return 0;
     default:
-      errx(1, "Usage: %s [-n] [-f]", __progname);
+      errx(1, "Usage: %s [-n] [-f] [-d] [-w] [-B]", __progname);
     }
+
+  if (do_wtmp)
+    write_wtmp(0);
 
   if (do_sync)
     sync();

--- a/halt.c
+++ b/halt.c
@@ -18,6 +18,10 @@ typedef enum {NOOP, HALT, REBOOT, POWEROFF} action_type;
 #define OUR_WTMP "/var/log/wtmp"
 #endif
 
+#ifndef OUR_UTMP
+#define OUR_UTMP "/run/utmp"
+#endif
+
 void write_wtmp(int boot) {
   int fd;
 
@@ -42,6 +46,13 @@ void write_wtmp(int boot) {
 
   write(fd, (char *)&utmp, sizeof(utmp));
   close(fd);
+
+  if (boot) {
+    if ((fd = open(OUR_UTMP, O_WRONLY|O_APPEND)) < 0)
+      return;
+    write(fd, (char *)&utmp, sizeof utmp);
+    close(fd);
+  }
 }
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
This implements -w and -d.

Also add -B to create boot-time wtmp entries.

Closes #27.