### PR TITLE
[RFC] Add oneshot capability

### DIFF
--- a/2
+++ b/2
@@ -13,6 +13,10 @@ done
 
 [ -x /etc/rc.local ] && /etc/rc.local
 
+for script in /etc/rc.local.d/??-*.sh; do
+    [ -x $script ] && $script
+done
+
 runsvchdir "${runlevel}"
 mkdir -p /run/runit/runsvdir
 ln -s /etc/runit/runsvdir/current /run/runit/runsvdir/current

--- a/3
+++ b/3
@@ -18,6 +18,10 @@ sv exit /var/service/*
 
 [ -x /etc/rc.shutdown ] && /etc/rc.shutdown
 
+for script in /etc/rc.shutdown.d/??-*.sh; do
+    [ -x $script ] && $script
+done
+
 if [ -z "$VIRTUALIZATION" ]; then
     msg "Saving random seed..."
     ( umask 077; bytes=$(cat /proc/sys/kernel/random/poolsize) || bytes=512; dd if=/dev/urandom of=/var/lib/random-seed count=1 bs=$bytes >/dev/null 2>&1 )


### PR DESCRIPTION
This is a simple solution to address #23. 

- To disable a oneshot, simply chmod -x it. I guess a package would have to mark these as `conf_files`? That does mean if they are edited, that there will be extra files in there (`XX-thing.sh.new-ver`) but those won't match the glob and it should be fine.
- I had suggested earlier there be "early boot" and "late boot" scripts, but given the nature of how runit starts services, this is silly since you can't really know if the services will all be started or not. This will suffice for the main use cases, which things like alsa and iptables.
- I also had suggested earlier that locations like `/etc/runit/oneshot` be used, but `/etc/rc.local.d` is a thing on other distributions, so I think that's more of a normal location to go with.

Comments? Questions?