### PR TITLE
fix(urandom): avoid uninitialized read during boot

### DIFF
--- a/core-services/05-misc.sh
+++ b/core-services/05-misc.sh
@@ -6,7 +6,6 @@ halt -B  # for wtmp
 if [ -z "$VIRTUALIZATION" ]; then
     msg "Initializing random seed..."
     cp /var/lib/random-seed /dev/urandom >/dev/null 2>&1 || true
-    ( umask 077; bytes=$(cat /proc/sys/kernel/random/poolsize) || bytes=512; dd if=/dev/urandom of=/var/lib/random-seed count=1 bs=$bytes >/dev/null 2>&1 )
 fi
 
 msg "Setting up loopback interface..."


### PR DESCRIPTION
Regenerating the stored seed was an attempt to prevent hard shutdowns
from leading to seed reuse.
Unfortunately, this practice depletes any entropy that was added by
the seed.
Furthermore on newer kernels which do not credit entropy added from
userspace, the operation is often an uninitialized read of urandom.