### PR TITLE
fix(sysctl): behave more like sysctl --system

### DIFF
--- a/core-services/08-sysctl.sh
+++ b/core-services/08-sysctl.sh
@@ -2,15 +2,19 @@
 
 if [ -x /sbin/sysctl -o -x /bin/sysctl ]; then
     msg "Loading sysctl(8) settings..."
+    mkdir -p /run/vsysctl.d
     for i in /run/sysctl.d/*.conf \
         /etc/sysctl.d/*.conf \
         /usr/local/lib/sysctl.d/*.conf \
-        /usr/lib/sysctl.d/*.conf \
-        /etc/sysctl.conf; do
+        /usr/lib/sysctl.d/*.conf; do
 
-        if [ -e "$i" ]; then
-            printf '* Applying %s ...\n' "$i"
-            sysctl -p "$i"
+        if [ -e "$i" ] && [ ! -e "/run/vsysctl.d/${i##*/}" ]; then
+            ln -s "$i" "/run/vsysctl.d/${i##*/}"
         fi
     done
+    for i in /run/vsysctl.d/*.conf; do
+        sysctl -p "$i"
+    done
+    rm -rf -- /run/vsysctl.d
+    sysctl -p /etc/sysctl.conf
 fi


### PR DESCRIPTION
Loading of sysctl.d directories should follow the same ordering and
overriding rules as xbps, modules-load, and most importantly,
`sysctl --system`.
This change ensures proper ordering of files loaded by building the
selected files then operating on them, and it allows for masking system
level configuration from /etc and even /run.