### PR TITLE
rc.conf: add note recommending /etc/localtime

### DIFF
--- a/rc.conf
+++ b/rc.conf
@@ -10,7 +10,13 @@
 # Set RTC to UTC or localtime.
 #HARDWARECLOCK="UTC"
 
-# Set timezone, availables timezones at /usr/share/zoneinfo.
+# Set timezone, availables timezones can be found at /usr/share/zoneinfo.
+#
+# NOTE: it's preferred to set the timezone in /etc/localtime instead:
+#  - ln -sf /usr/share/zoneinfo/<timezone> /etc/localtime
+# Setting the timezone here requires a reboot to apply any changes/fixes
+# and read-write access to the filesystem.
+#
 #TIMEZONE="Europe/Madrid"
 
 # Keymap to load, see loadkeys(8).


### PR DESCRIPTION
Recommend users to symlink their timezone to /etc/localtime instead of
setting TZ in /etc/rc.conf.

Following @Duncaen 's recommendation.