### PR TITLE
Set flag to enable cgroup memory hierarchy.

### DIFF
--- a/core-services/00-pseudofs.sh
+++ b/core-services/00-pseudofs.sh
@@ -12,5 +12,6 @@ mountpoint -q /sys/kernel/security || mount -n -t securityfs securityfs /sys/ker
 
 if [ -z "$VIRTUALIZATION" ]; then
     mountpoint -q /sys/fs/cgroup || mount -o mode=0755 -t tmpfs cgroup /sys/fs/cgroup
+    echo 1 > /sys/fs/cgroup/memory.use_hierarchy
     awk '$4 == 1 { system("mountpoint -q /sys/fs/cgroup/" $1 " || { mkdir -p /sys/fs/cgroup/" $1 " && mount -t cgroup -o " $1 " cgroup /sys/fs/cgroup/" $1 " ;}" ) }' /proc/cgroups
 fi


### PR DESCRIPTION
Containerization tools, such as Docker, want cgroup memory hierarchy enabled.

Since the flag **must** be enabled prior to use, the change must occur here. I originally tried to cleanly add this to the Docker `runit` service scripts, but failed - it'd be far more complicated than necessary.

I am running this change currently and it works.

Best regards,
-Joe