### PR TITLE
crypt.awk: support PARTUUID in /etc/crypttab

### DIFF
--- a/crypt.awk
+++ b/crypt.awk
@@ -3,7 +3,7 @@ NF>4 { print "a valid crypttab has max 4 cols not " NF >"/dev/stderr"; next }
 {
     # decode the src variants
     split($2, o_src, "=")
-    if (o_src[1] == "UUID") ("blkid -l -o device -t " $2) | getline src;
+    if (o_src[1] == "UUID" || o_src[1] == "PARTUUID") ("blkid -l -o device -t " $2) | getline src;
     else src=o_src[1];
 
     # no password or none is given, ask fo it


### PR DESCRIPTION
With encrypted swap using disposable keys (`/dev/urandom`), one cannot use a `UUID` because there is no consistent UUID associated with the swap device. A better specifier is PARTUUID, which is a property of the partition table that will not change with each invocation of `mkswap`. This alters the `crypt.awk` script to recognize device specifiers of the form `PARTUUID=<partition-uuid>` as it does `UUID` to properly detect swap devices.