### PR TITLE
Fix `ctrlaltdel` and `1` for stopit and reboot files

### DIFF
--- a/1
+++ b/1
@@ -12,7 +12,7 @@ msg "Welcome to Void!"
 # Start core services: one-time system tasks.
 detect_virt
 for f in /etc/runit/core-services/*.sh; do
-    [ -r $f ] && . $f
+	[ -r $f ] && . $f
 done
 
 dmesg >/var/log/dmesg.log
@@ -22,7 +22,9 @@ else
 	chmod 0644 /var/log/dmesg.log
 fi
 
+# create files for controlling runit
 mkdir -p /run/runit
-install -m100 /dev/null /run/runit/stopit
+install -m000 /dev/null /run/runit/stopit
+install -m000 /dev/null /run/runit/reboot
 
 msg "Initialization complete, running stage 2..."

--- a/3
+++ b/3
@@ -7,10 +7,6 @@ PATH=/usr/bin:/usr/sbin
 detect_virt
 [ -r /etc/rc.conf ] && . /etc/rc.conf
 
-if [ -e /run/runit/reboot ]; then
-    chmod 100 /run/runit/reboot
-fi
-
 echo
 msg "Waiting for services to stop..."
 sv force-stop /var/service/*

--- a/ctrlaltdel
+++ b/ctrlaltdel
@@ -3,8 +3,11 @@
 PATH=/usr/bin:/usr/sbin
 MSG="System is going down..."
 
+# We check for this file after receiving a SIGCONT to move to stage3
+chmod 100 /run/runit/stopit
+
 # We check for this file in stage3 to halt or reboot
-touch /run/runit/reboot
+chmod 100 /run/runit/reboot
 
 # Proceed with shutdown process
 echo "$MSG" | wall


### PR DESCRIPTION
Fixes #47 

Since the `halt` program seems to use `init` directly, I don't think anything else needs to be changed.

Needs proper testing as well.

Ping @Duncaen and @leahneukirchen 