### PR TITLE
Tidy up runsvdir symlinks during runit phase 1, so that the preparing…

### DIFF
--- a/core-services/99-cleanup.sh
+++ b/core-services/99-cleanup.sh
@@ -1,5 +1,16 @@
 # vim: set ts=4 sw=4 et:
 
+# runsvchdir chokes if the current and/or previous symlinks are broken
+if [ -e /etc/runit/runsvdir/previous ]; then
+	rm /etc/runit/runsvdir/previous
+fi
+if [ -e /etc/runit/runsvdir/current ]; then
+	rm /etc/runit/runsvdir/current
+fi
+# Set the initial runlevel to 'default', even if a different one
+# is being selected through the kernel command line (see /etc/runit/2)
+ln -s default /etc/runit/runsvdir/current
+
 if [ ! -e /var/log/wtmp ]; then
 	install -m0664 -o root -g utmp /dev/null /var/log/wtmp
 fi


### PR DESCRIPTION
… execution of runsvchdir in phase 2 doesn't choke, if those symlinks are broken.

---

I just stumbled over my system not being able to fully enter runit phase 2, due to me messing around with the service directories and leaving behind broken `current` and `default` symlinks. This little patch adds extra cleanup that tidies up by always entering phase 2 with `current → default` and `previous` being removed.