### PR TITLE
[RFC] Add polkit actions for zzz, ZZZ

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ install:
 	ln -sf /run/runit/stopit ${DESTDIR}/etc/runit/
 	cp -R --no-dereference --preserve=mode,links -v runsvdir/* ${DESTDIR}/etc/runit/runsvdir/
 	cp -R --no-dereference --preserve=mode,links -v services/* ${DESTDIR}/etc/sv/
+	install -d ${DESTDIR}/${PREFIX}/share/polkit-1/actions
+	install -m644 polkit-actions/org.voidlinux.zzz.policy ${DESTDIR}/${PREFIX}/share/polkit-1/actions
 
 clean:
 	-rm -f halt pause vlogger

--- a/polkit-actions/org.voidlinux.zzz.policy
+++ b/polkit-actions/org.voidlinux.zzz.policy
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN" "https://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
+<policyconfig>
+  <vendor>org.voidlinux</vendor>
+  <vendor_url>https://voidlinux.org</vendor_url>
+  <action id="org.voidlinux.pkexec.zzz">
+    <description>Suspend or hibernate your computer</description>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/zzz</annotate>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/ZZZ</annotate>
+  </action>
+</policyconfig>


### PR DESCRIPTION
I noticed that some applications, for example [brillo](https://github.com/void-linux/void-packages/blob/master/srcpkgs/brillo/template), are available for execution by regular users through pkexec without additional configuration.

Why not add this ability to some void-runit scripts?