### PR TITLE
Support pure v2 cgroup mounts

### DIFF
--- a/rc.conf
+++ b/rc.conf
@@ -33,3 +33,10 @@
 
 # Amount of ttys which should be setup.
 #TTYS=
+
+# Set the mode for cgroup mounts.
+# hybrid: mount cgroup v1 under /sys/fs/cgroup and
+#         cgroup v2 under /sys/fs/cgroup/unified
+# legacy: mount cgroup v1 /sys/fs/cgroup
+# unified: mount cgroup v2 under /sys/fs/cgroup
+#CGROUP_MODE=hybrid


### PR DESCRIPTION
Some of the tooling with the support for cgroups v2 (notably container tools like podman, crun and runc) [check](https://github.com/containers/podman/blob/8b377a79c240e4480339358db3b87263ec6cfef3/pkg/cgroups/cgroups_supported.go#L25-L35) `cgroup v2` availability via the fs magic number on  the `/sys/fs/cgroup`. Hybrid mode (used by void) is not as useful afaik due to inability to map v1 and v2 controllers at the same time. This patch introduces support for pure v1 (legacy) and v2 (unified) cgroups mounts while preserving the current v2 under v1 (hybrid) mode as a default. These modes are modeled after [OpenRC](https://github.com/OpenRC/openrc/blob/72df51e17ba0e1a0f94451b4bbfb338288c4625c/init.d/cgroups.in#L121-L129).