### PR TITLE
core-services/03-filesystems.sh: load keys as necessary when mounting

### DIFF
--- a/core-services/03-filesystems.sh
+++ b/core-services/03-filesystems.sh
@@ -40,7 +40,7 @@ if [ -x /usr/bin/zpool -a -x /usr/bin/zfs ]; then
     fi
 
     msg "Mounting ZFS file systems..."
-    zfs mount -a
+    zfs mount -a -l
 
     msg "Sharing ZFS file systems..."
     zfs share -a


### PR DESCRIPTION
This fixes early-boot automounting for users of native encryption in ZFS.

`zfs mount -a` will mount every ZFS filesystem with a valid `mountpoint` property and not explicitly prevented from mounting or automounting---except for any encrypted filesystem protected with a key that has not previously been loaded. At early boot, the only key that has been loaded is the one needed for the root mount, so any other encrypted filesystem with a different `encryptionroot` will not be automounted.

Using `zfs mount -a -l` will cause ZFS to attempt to load any key it needs to auto-mount an encrypted filesystem. For filesystems whose `keylocation` properties are a `file:///` URL, this will happen silently. For filesystems with a `prompt` keylocation, this will block the terminal awaiting user entry for every necessary password.

Yes, prompts for multiple `encryptionroot`s can be annoying. No, it is not more annoying than expecting ZFS automount to work and discovering after the fact that some of them have not been. If users don't want to be prompted at boot time for multiple passwords, they should
- Use a `file://` key rather than a `prompt` key,
- Put all encrypted filesystems under the same `encryptionroot` as the root filesystem, or
- Disable automounting of filesystems they don't want to unlock at boot.

cc: @ericonr @zdykstra and anybody else using ZFS regularly