### PR TITLE
services/agetty-generic: use chpst -P instead of setsid

### DIFF
--- a/services/agetty-generic/run
+++ b/services/agetty-generic/run
@@ -12,5 +12,5 @@ elif [ -x /sbin/agetty -o -x /bin/agetty ]; then
 	GETTY=agetty
 fi
 
-exec setsid ${GETTY} ${GETTY_ARGS} \
+exec chpst -P ${GETTY} ${GETTY_ARGS} \
 	"${tty}" "${BAUD_RATE}" "${TERM_NAME}"


### PR DESCRIPTION
The setsid program has a surprise gotcha of backgrounding a process if
it already happens to be the session leader. This is ok for runit which
never sets the service as a session leader but does not work with other
supervisors which might. chpst provides the same setsid(2) functionality
without also having the gotcha.