### PR TITLE
core-services/03-filesystems.sh: respect auto_activation_volume_list

### DIFF
--- a/core-services/03-filesystems.sh
+++ b/core-services/03-filesystems.sh
@@ -17,7 +17,7 @@ fi
 
 if [ -x /sbin/vgchange -o -x /bin/vgchange ]; then
     msg "Activating LVM devices..."
-    vgchange --sysinit -a y || emergency_shell
+    vgchange --sysinit -a ay || emergency_shell
 fi
 
 if [ -e /etc/crypttab ]; then
@@ -26,7 +26,7 @@ if [ -e /etc/crypttab ]; then
 
     if [ -x /sbin/vgchange -o -x /bin/vgchange ]; then
         msg "Activating LVM devices for dm-crypt..."
-        vgchange --sysinit -a y || emergency_shell
+        vgchange --sysinit -a ay || emergency_shell
     fi
 fi
 


### PR DESCRIPTION
If `auto_activation_volume_list` is set in `lvm.conf`, this action will ensure that its respected when activating.  If its unset, there should be no behavior change.

Closes #64.