### PR TITLE
halt: switch __progname tests to use strncmp

### DIFF
--- a/halt.c
+++ b/halt.c
@@ -63,11 +63,11 @@ int main(int argc, char *argv[]) {
   int opt;
   action_type action = NOOP;
 
-  if (strcmp(__progname, "halt") == 0)
+  if (strncmp(__progname, "halt", 4) == 0)
     action = HALT;
-  else if (strcmp(__progname, "reboot") == 0)
+  else if (strncmp(__progname, "reboot", 6) == 0)
     action = REBOOT;
-  else if (strcmp(__progname, "poweroff") == 0)
+  else if (strncmp(__progname, "poweroff", 8) == 0)
     action = POWEROFF;
   else
     warnx("no default behavior, needs to be called as halt/reboot/poweroff.");


### PR DESCRIPTION
The pending change to allow for alternate init power controls requires
that the halt binary provided here be somewhat less strict in its
argv[0] matching in order to allow for halt, reboot, and poweroff to
still function in situations where the binary has been renamed.

This switches from strcmp(__progname, "string") to strncmp(__progname,
"string", len), where len is the name of the power command sans any
suffix.

Signed-off-by: Colin Booth <colin@heliocat.net>