### PR TITLE
Activate mdadm arrays on boot

### DIFF
--- a/core-services/03-filesystems.sh
+++ b/core-services/03-filesystems.sh
@@ -10,6 +10,11 @@ if [ -x /sbin/dmraid -o -x /bin/dmraid ]; then
     dmraid -i -ay
 fi
 
+if [ -x /bin/mdadm ]; then
+    msg "Activating software RAID arrays..."
+    mdadm -As
+fi
+
 if [ -x /bin/btrfs ]; then
     msg "Activating btrfs devices..."
     btrfs device scan || emergency_shell


### PR DESCRIPTION
My Void server reboots to the emergency shell every time, because I have a software RAID 5 array in `/etc/fstab` that's never started.

I suspect that other people are using mdadm arrays without issue and I could be missing something elsewhere, perhaps in dracut, but a PR is as fine a place as any to hash that out.
