### PR TITLE
core-services/00-pseudofs: mount /sys/firmware/efi/efivars when appropriate

### DIFF
--- a/core-services/00-pseudofs.sh
+++ b/core-services/00-pseudofs.sh
@@ -10,6 +10,10 @@ mountpoint -q /dev/pts || mount -o mode=0620,gid=5,nosuid,noexec -n -t devpts de
 mountpoint -q /dev/shm || mount -o mode=1777,nosuid,nodev -n -t tmpfs shm /dev/shm
 mountpoint -q /sys/kernel/security || mount -n -t securityfs securityfs /sys/kernel/security
 
+if [ -d /sys/firmware/efi/efivars ]; then
+    mountpoint -q /sys/firmware/efi/efivars || mount -o nosuid,noexec,nodev -t efivarfs efivarfs /sys/firmware/efi/efivars
+fi
+
 if [ -z "$VIRTUALIZATION" ]; then
     _cgroupv1=""
     _cgroupv2=""


### PR DESCRIPTION
Since we switched to CONFIG_EFIVAR_FS, this needs to be mounted explicitly for things like efibootmgr to work.

Systemd also mounts it on boot, so in core-services should be fine.

The `[ -d ]` should gate EFI boots only.