### PR TITLE
Add support for shutdown hooks automatically executed by rc.shutdown.

### DIFF
--- a/rc.shutdown
+++ b/rc.shutdown
@@ -2,3 +2,7 @@
 #
 # This is run by runit in stage 3 after the services are stopped
 # (see /etc/runit/3).
+
+for hook in /etc/shutdown.d/* ; do
+  [ -x "$hook" ] && "$hook"
+done


### PR DESCRIPTION
The motivation for this is to provide easier support for packages that
need to add custom logic at system shutdown. During package
installation, instead of patching logic into /etc/rc.shutdown, it can
simply be added as executable files to /etc/shutdown.d/, similar to
/etc/zzz.d/{suspend,resume}/.