### PR TITLE
Only try to run kexec on reboot

### DIFF
--- a/shutdown.d/90-kexec.sh
+++ b/shutdown.d/90-kexec.sh
@@ -1,5 +1,5 @@
 if [ -z "$VIRTUALIZATION" ]; then
-    if [ -e /run/runit/reboot ] && command -v kexec >/dev/null; then
+    if [ -x /run/runit/reboot ] && command -v kexec >/dev/null; then
         msg "Triggering kexec..."
         kexec -e 2>/dev/null
         # not reached when kexec was successful.


### PR DESCRIPTION
I have recently fooled around with kexec and found a small issue. Commits 05c6e86e085e0c0fdfc84a013477efd51e700845 and df580011835bff76fc0d4473f52344898abd9ef5 changed how `/run/runit/reboot` works, which results in `if [ -e /run/runit/reboot ]` always evaluating to true. This means that when the system is trying to shut down, not reboot, and kexec-tools is installed, it will try to kexec into a new kernel. Of course, this fails when there is no kernel loaded for kexec, but if there is one the system will reboot instead of shutting it down.

Changing the line to an executable check on `/run/runit/reboot` makes it work as expected on my end, trying to kexec on reboot but not on shutdown.