### PR TITLE
Feature: Add rc.pre-shutdown as new configuration file

### DIFF
--- a/3
+++ b/3
@@ -8,6 +8,8 @@ detect_virt
 [ -r /etc/rc.conf ] && . /etc/rc.conf
 
 echo
+[ -x /etc/rc.pre-shutdown ] && /etc/rc.pre-shutdown
+
 msg "Waiting for services to stop..."
 sv force-stop /var/service/*
 sv exit /var/service/*

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ install:
 	install -m644 crypt.awk  ${DESTDIR}/etc/runit
 	install -m644 rc.conf ${DESTDIR}/etc
 	install -m755 rc.local ${DESTDIR}/etc
+	install -m755 rc.pre-shutdown ${DESTDIR}/etc
 	install -m755 rc.shutdown ${DESTDIR}/etc
 	install -d ${DESTDIR}/${PREFIX}/lib/dracut/dracut.conf.d
 	install -m644 dracut/*.conf ${DESTDIR}/${PREFIX}/lib/dracut/dracut.conf.d

--- a/rc.pre-shutdown
+++ b/rc.pre-shutdown
@@ -1,0 +1,4 @@
+# Default rc.pre-shutdown for void; add your custom commands here.
+#
+# This is run by runit in stage 3 before the services are stopped
+# (see /etc/runit/3).


### PR DESCRIPTION
Hello,

after installing void-linux on my laptop, I came pretty fast to the conclusion, that I need the option to execute some things before the services are stopped by runit.

For this I introducing rc.pre-shutdown as a configuration file for things that must be executed before the services are stopped.

I'm already using this on my daily driver laptop.

Since I don't yet know which other things need to be updated I hope you can help me with
implementing this feature?

Regards,
Ben