### PR TITLE
Prevent zzz suspend and resume hooks from inheriting lock

### DIFF
--- a/zzz
+++ b/zzz
@@ -44,7 +44,7 @@ flock -n 9 || fail "another instance of zzz is running"
 printf "Zzzz... "
 
 for hook in /etc/zzz.d/suspend/*; do
-  [ -x "$hook" ] && "$hook"
+  [ -x "$hook" ] && "$hook" 9>&-
 done
 
 case "$ZZZ_MODE" in
@@ -57,7 +57,7 @@ case "$ZZZ_MODE" in
 esac
 
 for hook in /etc/zzz.d/resume/*; do
-  [ -x "$hook" ] && "$hook"
+  [ -x "$hook" ] && "$hook" 9>&-
 done
 
 echo "yawn."


### PR DESCRIPTION
This stops screenlockers started from zzz hooks from preventing zzz to run again.

Examples:
1. open laptop lid to check whether there is power on and close again.
2. Accidentally touch desktop keyboard waking it and not unlocking, but some form of inactivity timeout is set up, so that it suspends.

Those cases don't currently work unless the user of the hooks somehow know that they have to close fd per process.