### PR TITLE
update detect_virt to work on recent lxc/d

### DIFF
--- a/functions
+++ b/functions
@@ -30,6 +30,7 @@ emergency_shell() {
 detect_virt() {
    # Detect LXC (and other) containers
    [ -z "${container+x}" ] || export VIRTUALIZATION=1
+   [ -r /proc/1/environ ] && grep -qa "container=lx" /proc/1/environ && export VIRTUALIZATION=1
 }
 
 deactivate_vgs() {


### PR DESCRIPTION
`detect_virt` does not set `VIRTUALIZATION` in later versions of lxd containers. I added a second check that should work.

This might be able to be better optimized (that is, right now, both checks are run regardless of the output of the first check), but as this is probably an infrequently-run function, it shouldn't be a big deal.

I've confirmed this is working on bare-metal void (where it's not set) and in void lxd containers (v5.9, where it is set).