### PR TITLE
pseudofs: cgroup: various improvements

### DIFF
--- a/core-services/00-pseudofs.sh
+++ b/core-services/00-pseudofs.sh
@@ -18,7 +18,7 @@ if [ -z "$VIRTUALIZATION" ]; then
     _cgroupv1=""
     _cgroupv2=""
 
-    case "${CGROUP_MODE:-hybrid}" in
+    case "${CGROUP_MODE:-unified}" in
         legacy)
             _cgroupv1="/sys/fs/cgroup"
             ;;
@@ -40,11 +40,27 @@ if [ -z "$VIRTUALIZATION" ]; then
             mkdir -p "$_controller"
             mountpoint -q "$_controller" || mount -t cgroup -o "$_subsys_name" cgroup "$_controller"
         done < /proc/cgroups
+        # always mount the systemd tracking cgroup,
+        # to support containerized systemd instances
+        mkdir -p /sys/fs/cgroup/systemd
+        mountpoint -q /sys/fs/cgroup/systemd || \
+            mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd
     fi
 
     # cgroup v2
     if [ -n "$_cgroupv2" ]; then
         mkdir -p "$_cgroupv2"
-        mountpoint -q "$_cgroupv2" || mount -t cgroup2 -o nsdelegate cgroup2 "$_cgroupv2"
+        mountpoint -q "$_cgroupv2" || \
+            mount -t cgroup2 -o nsdelegate cgroup2 "$_cgroupv2"
+    fi
+else
+    # in containers, unless otherwise configured,
+    # attempt to mount cgroup2 at the standard path,
+    # but never fail
+    if [ "${CGROUP_MODE:-unified}" = "unified" ]; then
+        _cgroup2="/sys/fs/cgroup"
+        mkdir -p "$_cgroup2"
+        mountpoint -q "$_cgroup2" || \
+            mount -t cgroup2 -o nsdelegate cgroup2 "$_cgroup2" || true
     fi
 fi

--- a/rc.conf
+++ b/rc.conf
@@ -39,7 +39,7 @@
 #         cgroup v2 under /sys/fs/cgroup/unified
 # legacy: mount cgroup v1 /sys/fs/cgroup
 # unified: mount cgroup v2 under /sys/fs/cgroup
-#CGROUP_MODE=hybrid
+#CGROUP_MODE=unified
 
 # Set this to true only if you do not want seed files to actually credit the
 # RNG, for example if you plan to replicate this file system image and do not


### PR DESCRIPTION
Default to cgroup2
Attempt to mount cgroup2 in containers to support nesting
Mount the systemd tracking cgroup when using cgroup1

Closes https://github.com/void-linux/void-runit/issues/74

---

Former title: rough thoughts on cgroup1 and cgroup2  
Former description:

cgroup1

the various container tool run scripts variably handle certain cases,
namely that of the systemd tracking cgroup.

i am actually not 100% confident on why that cgroup needs to be mounted,
but i imagine it has to do with the needs of systemd instances that may
be running in containers.

anyway supposedly it needed to be mounted at one point so the run
scripts would do it. but if the run scripts did it, it could not have
been that harmful. so just do it always. (in legacy/hybrid mode, which I
have not been using for some time).

cgroup2

alright so while we are at it default to pure-cgroup2 / "unified".
i don't know why anyone would want to use a hybrid. and i own a phev.
cgroup2 is just a better default. more compatible and future proof.

to top it off, start mounting cgroup2 when running in a container.
because LXD can not or will not do that for us, the container.
this actually ignores rc.conf completely. might need some work
