### PR TITLE
Migrate the creation of runit control files from stage 1 script to core-services

### DIFF
--- a/1
+++ b/1
@@ -22,9 +22,4 @@ else
 	chmod 0644 /var/log/dmesg.log
 fi
 
-# create files for controlling runit
-mkdir -p /run/runit
-install -m000 /dev/null /run/runit/stopit
-install -m000 /dev/null /run/runit/reboot
-
 msg "Initialization complete, running stage 2..."

--- a/core-services/10-runit-control.sh
+++ b/core-services/10-runit-control.sh
@@ -1,0 +1,6 @@
+# vim: set ts=4 sw=4 et:
+
+# create files for controlling runit
+mkdir -p /run/runit
+install -m000 /dev/null /run/runit/stopit
+install -m000 /dev/null /run/runit/reboot


### PR DESCRIPTION
This change allows later customization of the runit control files (`/run/runit/stopit`, et al.) via core-services instead of having to override in `/etc/rc.local`. This is an enabler of a solution to https://github.com/lxc/lxc-ci/issues/408, discussed also in https://github.com/void-linux/void-runit/pull/50.

This PR will make the following (nonbreaking) change to the startup process: currently the runit control files are created AFTER the dmesg chmod in `1`. Because core services are executed before the dmesg chmod, this means that the runit control files will be created BEFORE the dmesg chmod. Since runit and dmesg are independent, this should not cause any issues. (A separate question is whether we should move the dmesg work into core services, thus making `1` just a simple executor of core services.)

After this change, folks using lxd or incus containers will be able to create their own lower-priority core service to modify the permissions on the files to enable proper shutdown/reboot of the containers. These core services will survive upgrades to `void-runit`, unlike the current approach in the container script.

