### PR TITLE
core-services/03-filesystems.sh: force legacy mount iface for remount

### DIFF
--- a/core-services/03-filesystems.sh
+++ b/core-services/03-filesystems.sh
@@ -3,7 +3,7 @@
 [ -n "$VIRTUALIZATION" ] && return 0
 
 msg "Remounting rootfs read-only..."
-mount -o remount,ro / || emergency_shell
+LIBMOUNT_FORCE_MOUNT2=always mount -o remount,ro / || emergency_shell
 
 if [ -x /sbin/dmraid -o -x /bin/dmraid ]; then
     msg "Activating dmraid devices..."
@@ -74,7 +74,7 @@ if [ -z "$FASTBOOT" ]; then
 fi
 
 msg "Mounting rootfs read-write..."
-mount -o remount,rw / || emergency_shell
+LIBMOUNT_FORCE_MOUNT2=always mount -o remount,rw / || emergency_shell
 
 msg "Mounting all non-network filesystems..."
 mount -a -t "nosysfs,nonfs,nonfs4,nosmbfs,nocifs" -O no_netdev || emergency_shell

--- a/shutdown.d/80-filesystems.sh
+++ b/shutdown.d/80-filesystems.sh
@@ -3,7 +3,7 @@ if [ -z "$VIRTUALIZATION" ]; then
     swapoff -a
     umount -r -a -t nosysfs,noproc,nodevtmpfs,notmpfs
     msg "Remounting rootfs read-only..."
-    mount -o remount,ro /
+    LIBMOUNT_FORCE_MOUNT2=always mount -o remount,ro /
 fi
 
 sync


### PR DESCRIPTION
With util-linux>=2.40, filesystems that do not support remounting with different options fail because the new kernel mount interface is used. This breaks booting an overlayfs (like live ISOs).

By setting `LIBMOUNT_FORCE_MOUNT2=always`, we force `mount(8)` to use the old kernel mount interface, which ignores changed options.

Tested in mklive to ensure overlayfs root works.

see also:
* https://github.com/util-linux/util-linux/issues/2576
* https://github.com/void-linux/void-mklive/issues/369
