### PR TITLE
1, core-services: migrate towards core-services

### DIFF
--- a/1
+++ b/1
@@ -15,16 +15,4 @@ for f in /etc/runit/core-services/*.sh; do
 	[ -r $f ] && . $f
 done
 
-dmesg >/var/log/dmesg.log
-if [ $(sysctl -n kernel.dmesg_restrict 2>/dev/null) -eq 1 ]; then
-	chmod 0600 /var/log/dmesg.log
-else
-	chmod 0644 /var/log/dmesg.log
-fi
-
-# create files for controlling runit
-mkdir -p /run/runit
-install -m000 /dev/null /run/runit/stopit
-install -m000 /dev/null /run/runit/reboot
-
 msg "Initialization complete, running stage 2..."

--- a/core-services/10-runit-control.sh
+++ b/core-services/10-runit-control.sh
@@ -1,0 +1,6 @@
+# vim: set ts=4 sw=4 et:
+
+# create files for controlling runit
+mkdir -p /run/runit
+install -m000 /dev/null /run/runit/stopit
+install -m000 /dev/null /run/runit/reboot

--- a/core-services/97-dmesg.sh
+++ b/core-services/97-dmesg.sh
@@ -1,0 +1,8 @@
+# vim: set ts=4 sw=4 et:
+
+dmesg >/var/log/dmesg.log
+if [ $(sysctl -n kernel.dmesg_restrict 2>/dev/null) -eq 1 ]; then
+	chmod 0600 /var/log/dmesg.log
+else
+	chmod 0644 /var/log/dmesg.log
+fi


### PR DESCRIPTION
Based 100% on the work by @sbromberger

#113

I didn't want the work to die.

After this change, folks using lxd or incus containers will be able to create their own lower-priority core service to modify the permissions on the files to enable proper shutdown/reboot of the containers. These core services will survive upgrades to void-runit, unlike the current approach in the container script.