### PR TITLE
Check the write permission on `/sys/power/disk` when hibernate

### DIFF
--- a/zzz
+++ b/zzz
@@ -36,7 +36,10 @@ case "$ZZZ_MODE" in
   hibernate) grep -q disk /sys/power/state || fail "hibernate not supported";;
 esac
 
-test -w /sys/power/state || fail "sleep permission denied"
+if ! [ -w /sys/power/state ] || {
+   ! [ -w /sys/power/disk ] && [ "$ZZZ_MODE" = hibernate ];}; then
+  fail "sleep permission denied"
+fi
 
 (
 flock -n 9 || fail "another instance of zzz is running"


### PR DESCRIPTION
Currently, only the permission on `/sys/power/state` is tested, which may cause an unintended operating mode of hibernation if `/sys/power/disk` is not writable. With this PR, the permission on `/sys/power/disk` is also be tested.