### PR TITLE
10-runit-control: make a hardlink to the currently booted init

### DIFF
--- a/core-services/10-runit-control.sh
+++ b/core-services/10-runit-control.sh
@@ -4,3 +4,7 @@
 mkdir -p /run/runit
 install -m000 /dev/null /run/runit/stopit
 install -m000 /dev/null /run/runit/reboot
+
+# ensure runit keeps link count >0 if the binary is updated,
+# so the rootfs can be remounted read-only
+ln -f /bin/runit /bin/.runit.booted


### PR DESCRIPTION
This ensures the link count of the pid 1 executable remains positive when runit is updated.  If the link count is zero, the file system cannot be remounted read-only during shutdown, as the disk space needs to be reclaimed.