### PR TITLE
Update 10-runit-control.sh to install stopit and reboot as u+x

### DIFF
--- a/core-services/10-runit-control.sh
+++ b/core-services/10-runit-control.sh
@@ -2,5 +2,5 @@
 
 # create files for controlling runit
 mkdir -p /run/runit
-install -m000 /dev/null /run/runit/stopit
-install -m000 /dev/null /run/runit/reboot
+install -m100 /dev/null /run/runit/stopit
+install -m100 /dev/null /run/runit/reboot


### PR DESCRIPTION
Allows SIGCONT to runit to shutdown system. This is necessary for e.g. container control, where +x is required on `stopit`.

References:

- https://github.com/lxc/lxc-ci/issues/408#issuecomment-1873593295
- https://github.com/lxc/lxc-ci/issues/904

The patch implemented by incus in https://github.com/lxc/lxc-ci/commit/3aeae948fb2eb5ce861184a16255a4d56c7fe3cd will work until void-runit gets updated within a container, at which point the `/etc/runit/1` script will get overwritten.