### PR TITLE
Additional crypt.awk features

### DIFF
--- a/crypt.awk
+++ b/crypt.awk
@@ -45,6 +45,7 @@ NF>4 { print "a valid crypttab has max 4 cols not " NF >"/dev/stderr"; next }
             else if ( par == "offset" ) swapopts=swapopts "-o " val " ";
             else if ( par == "skip" ) swapopts=swapopts "-p " val " ";
             else if ( par == "verify" ) swapopts=swapopts "-y ";
+            else if ( par == "sector-size" ) swapopts=swapopts "--sector-size " val " ";
             #else if ( par == "noauto" )
             #else if ( par == "nofail" )
             #else if ( par == "plain" )


### PR DESCRIPTION
I've added support for using `LABEL=` and setting `sector-size=` in `/etc/crypttab`.

`sector-size` is just a common performance optimisation for encrypted swap

The justification for `LABEL` being useful can be found here: https://wiki.archlinux.org/title/Dm-crypt/Swap_encryption#UUID_and_LABEL